### PR TITLE
fix module path to make it go install-able

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module never18
+module github.com/kachick/never18
 
 go 1.20


### PR DESCRIPTION
Currently it is not `go install`-able
```
$ go install github.com/kachick/never18/cmd/never18@latest
go: github.com/kachick/never18/cmd/never18@latest: github.com/kachick/never18@v0.0.2: parsing go.mod:
        module declares its path as: never18
                but was required as: github.com/kachick/never18
```

module path should be `github.com/kachick/never18` to make it public.