### PR TITLE
Bump and pin to NixOS 24.05

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,14 +14,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dprint/check@v2.2
         with:
-          dprint-version: '0.45.1' # selfup { "regex": "\\d[^']+", "script": "dprint --version | cut -d ' ' -f 2" }
+          dprint-version: '0.45.1' # selfup {"extract":"\\d[^']+","replacer":["bash","-c","dprint --version | cut -d ' ' -f 2"]}
 
   typos:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.21.0 # selfup { "regex": "\\d\\.\\d+\\.\\d+", "script": "typos --version | cut -d ' ' -f 2" }
+      - uses: crate-ci/typos@v1.21.0 # selfup {"extract":"\\d\\.\\d+\\.\\d+","replacer":["bash","-c","typos --version | cut -d ' ' -f 2"]}
         with:
           files: |
             .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           distribution: goreleaser
-          version: 'v1.26.1' # selfup { "regex": "\\d[^']+", "script": "goreleaser --version | grep 'GitVersion:' | tr -s ' ' | cut -d ' ' -f 2" }
+          version: 'v1.26.1' # selfup {"extract":"\\d[^']+","replacer":["bash","-c","goreleaser --version | grep 'GitVersion:' | tr -s ' ' | cut -d ' ' -f 2"]}
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-nixpkgs-and-versions-in-ci.yml
+++ b/.github/workflows/update-nixpkgs-and-versions-in-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   update-nixpkgs:
-    uses: kachick/selfup/.github/workflows/reusable-bump-flake-lock-and-selfup.yml@action-v1
+    uses: kachick/selfup/.github/workflows/reusable-bump-flake-lock-and-selfup.yml@v1.1.2
     if: (github.event.sender.login == 'kachick') || (github.event_name != 'pull_request')
     with:
       dry-run: ${{ github.event_name == 'pull_request' }}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716509168,
-        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
+        "lastModified": 1716542732,
+        "narHash": "sha256-0Y9fRr0CUqWT4KgBITmaGwlnNIGMYuydu2L8iLTfHU4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
+        "rev": "d12251ef6e8e6a46e05689eeccd595bdbd3c9e60",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     #   - https://discourse.nixos.org/t/differences-between-nix-channels/13998
     # How to update the revision
     #   - `nix flake update --commit-lock-file` # https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake-update.html
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
- **Bump and pin to NixOS 24.05**
- **`git ls-files '.github/workflows/*.yml' | xargs nix run github:kachick/selfup/v1.1.2 -- migrate`**
- **Bump selfup action to follow new schema**
